### PR TITLE
Fix typo in chapter-09.md

### DIFF
--- a/chapter-09/chapter-09.md
+++ b/chapter-09/chapter-09.md
@@ -108,7 +108,7 @@ public class ModelLoader {
 }
 ```
 
-The rest of the code for the constructor is a as follows:
+The rest of the code for the constructor is as follows:
 
 ```java
 public class ModelLoader {


### PR DESCRIPTION
Edited "The rest of the code for the constructor is a as follows:" to "The rest of the code for the constructor is as follows:"