### PR TITLE
Add static import to GuiRender

### DIFF
--- a/chapter-10/chapter-10.md
+++ b/chapter-10/chapter-10.md
@@ -129,6 +129,7 @@ import java.nio.ByteBuffer;
 import java.util.*;
 
 import static org.lwjgl.opengl.GL32.*;
+import static org.lwjgl.glfw.GLFW.*;
 
 public class GuiRender {
 


### PR DESCRIPTION
All of the keyboard input constants (GLFW_KEY_1, etc.) are in org.lwjgl.glfw.GLFW, but they were never imported.